### PR TITLE
Potential fix for code scanning alert no. 4: Indirect uncontrolled command line

### DIFF
--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -9,7 +9,7 @@
  */
 
 import { readCachedProjectGraph } from '@nrwl/devkit';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import chalk from 'chalk';
 
@@ -60,4 +60,4 @@ try {
 }
 
 // Execute "npm publish" to publish
-execSync(`npm publish --access public --tag ${tag}`);
+execFileSync('npm', ['publish', '--access', 'public', '--tag', tag]);


### PR DESCRIPTION
Potential fix for [https://github.com/secretarium/devsuite-typescript/security/code-scanning/4](https://github.com/secretarium/devsuite-typescript/security/code-scanning/4)

To fix the problem, we should avoid using `execSync` with a concatenated string command. Instead, we should use `execFileSync` which accepts command arguments as an array of strings. This approach is safer and prevents command injection vulnerabilities.

We need to modify the `execSync` call on line 63 to use `execFileSync` and pass the command arguments as an array. This change will ensure that the `tag` variable is treated as a separate argument and not subject to shell interpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
